### PR TITLE
remove unsigned comment-header about the software

### DIFF
--- a/Formula/Patches/gnupg2/options.skel.patch
+++ b/Formula/Patches/gnupg2/options.skel.patch
@@ -50,7 +50,6 @@
 +# Try CERT, then PKA, then LDAP, then hkp://keys.gnupg.net:
 +auto-key-locate hkps://hkps.pool.sks-keyservers.net
 +
-+comment GPGTools - https://gpgtools.org
 +cert-digest-algo SHA512
 +default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
 +personal-digest-preferences SHA512 SHA384 SHA256 SHA224


### PR DESCRIPTION
Publishing a comment about the software being "GPGTools" in the OpenPGP armor header is not particularly helpful.
1. It is not cryptographically verifiable, it could be spoofed.
2. It has no technical meaning. Even RFC 4880 lists no pressing reason for including this by default.
3. It leaks metadata that can be used to distinguish users from one another. This has actually been done in real-world attacks: http://www.networkworld.com/article/2904395/microsoft-subnet/mistakes-that-betrayed-anonymity-of-former-dea-agent-and-silk-road-investigator.html

For all these reasons, GnuPG itself has made this default: http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=c9387e41db7520d176edd3d6613b85875bdeb32c

Let's also drop this in GPGTools.
