### PR TITLE
Add patch for supporting SHA-2 signatures using gpg-agent

### DIFF
--- a/Formula/MacGPG2.rb
+++ b/Formula/MacGPG2.rb
@@ -24,6 +24,7 @@ class Macgpg2 < Formula
     { :p1 => ["#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/other.patch",
               "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/socket.patch",
               "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/gpg-agent.patch",
+              "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/gpg-agent-sha-2.patch",
               "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/MacGPG2VersionString.patch",
               "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/passphrase-fd.patch",
               "#{HOMEBREW_PREFIX}/Library/Formula/Patches/gnupg2/exec_write_stderr.patch",

--- a/Formula/Patches/gnupg2/gpg-agent-sha-2.patch
+++ b/Formula/Patches/gnupg2/gpg-agent-sha-2.patch
@@ -1,0 +1,94 @@
+From 431f4a3e4db197a663264d628cd7db4b0352f64c Mon Sep 17 00:00:00 2001
+From: Damien Goutte-Gattat <dgouttegattat at incenp.org>
+Date: Sun, 7 Sep 2014 13:53:13 +0200
+Subject: [PATCH] Fix usage of SHA-2 algorithm with OpenPGP cards.
+
+Backport commit 1c09def22d97de3738a2bec4970504bfc155680b into the
+2.0.26 version.
+
+diff --git a/agent/agent.h b/agent/agent.h
+index 938a9aa..2c8dc75 100644
+--- a/agent/agent.h
++++ b/agent/agent.h
+@@ -370,6 +370,7 @@ int agent_card_pksign (ctrl_t ctrl,
+                        const char *keyid,
+                        int (*getpin_cb)(void *, const char *, char*, size_t),
+                        void *getpin_cb_arg,
++                       int mdalgo,
+                        const unsigned char *indata, size_t indatalen,
+                        unsigned char **r_buf, size_t *r_buflen);
+ int agent_card_pkdecrypt (ctrl_t ctrl,
+diff --git a/agent/call-scd.c b/agent/call-scd.c
+index 9a2e65e..9785696 100644
+--- a/agent/call-scd.c
++++ b/agent/call-scd.c
+@@ -804,13 +804,32 @@ inq_needpin (void *opaque, const char *line)
+ }
+ 
+ 
++/* Helper returning a command option to describe the used hash
++   algorithm. See scd/command.c:cmd_pksign.  */
++static const char *
++hash_algo_option (int algo)
++{
++  switch (algo)
++    {
++    case GCRY_MD_MD5   : return "--hash=md5";
++    case GCRY_MD_RMD160: return "--hash=rmd160";
++    case GCRY_MD_SHA1  : return "--hash=sha1";
++    case GCRY_MD_SHA224: return "--hash=sha224";
++    case GCRY_MD_SHA256: return "--hash=sha256";
++    case GCRY_MD_SHA384: return "--hash=sha384";
++    case GCRY_MD_SHA512: return "--hash=sha512";
++    default:             return "";
++    }
++}
+ 
+-/* Create a signature using the current card */
++/* Create a signature using the current card.  MDALGO is either 0 or
++   gives the digest algorithm.  */
+ int
+ agent_card_pksign (ctrl_t ctrl,
+                    const char *keyid,
+                    int (*getpin_cb)(void *, const char *, char*, size_t),
+                    void *getpin_cb_arg,
++                   int mdalgo,
+                    const unsigned char *indata, size_t indatalen,
+                    unsigned char **r_buf, size_t *r_buflen)
+ {
+@@ -844,8 +863,11 @@ agent_card_pksign (ctrl_t ctrl,
+   inqparm.getpin_cb = getpin_cb;
+   inqparm.getpin_cb_arg = getpin_cb_arg;
+   inqparm.passthru = 0;
+-  snprintf (line, DIM(line)-1, 
+-            ctrl->use_auth_call? "PKAUTH %s":"PKSIGN %s", keyid);
++  if (ctrl->use_auth_call)
++    snprintf (line, DIM(line)-1, "PKAUTH %s", keyid);
++  else
++    snprintf (line, DIM(line)-1, "PKSIGN %s %s",
++              hash_algo_option (mdalgo), keyid);
+   line[DIM(line)-1] = 0;
+   rc = assuan_transact (ctrl->scd_local->ctx, line,
+                         membuf_data_cb, &data,
+diff --git a/agent/divert-scd.c b/agent/divert-scd.c
+index 1f36f6e..ee5bcc7 100644
+--- a/agent/divert-scd.c
++++ b/agent/divert-scd.c
+@@ -347,7 +347,7 @@ divert_pksign (ctrl_t ctrl,
+       int save = ctrl->use_auth_call;
+       ctrl->use_auth_call = 1;
+       rc = agent_card_pksign (ctrl, kid, getpin_cb, ctrl,
+-                              digest, digestlen, &sigval, &siglen);
++                              algo, digest, digestlen, &sigval, &siglen);
+       ctrl->use_auth_call = save;
+     }
+   else
+@@ -359,7 +359,7 @@ divert_pksign (ctrl_t ctrl,
+       if (!rc)
+         {
+           rc = agent_card_pksign (ctrl, kid, getpin_cb, ctrl,
+-                                  data, ndata, &sigval, &siglen);
++                                  algo, data, ndata, &sigval, &siglen);
+           xfree (data);
+         }
+     }


### PR DESCRIPTION
This pull request integrates the patch for SHA-2 signatures through gpg-agent as discuessed in

https://lists.gnupg.org/pipermail/gnupg-devel/2014-September/028759.html

For whatever reason, this patch was never committed to the stable-2.0 branch and Werner Koch is refusing to accept any amendements to 2.0, see my discussion under https://bugs.gnupg.org/gnupg/issue3012

The symptom, which this pull request will fix is like follows:

*************************************************
$ gpg-connect-agent
> SIGKEY 44A7BBB8FD7AEBB001E0DA06A0A892EFC341C71E
OK
> SETHASH 8 79E12A66EFAAD785A443BB9787C8EF8A87F0DF4AA9669C452FCEBC67D323C42B
OK
> PKSIGN
ERR 100663351 Invalid value <SCD>
*************************************************

TIA for taking my pull request into account, Wolfgang