### PR TITLE
shutdown-gpg-agent script cleanup

### DIFF
--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -4,6 +4,7 @@ PROGRAM_NAME="gpg-agent"
 LOGFILE="$HOME/Library/Logs/shutdown-gpg-agent.log"
 AGENT_SOCKET_DEFAULT="$HOME/.gnupg/S.gpg-agent"
 AGENT_SOCKET_ALT="/tmp/gpg-agent/$USER/S.gpg-agent"
+SLEEP_PID=
 
 log() {
     current_date=$(date "+%Y-%m-%d %H:%M:%S")
@@ -16,6 +17,10 @@ log() {
 onExit() {
     # Ignore future HUP, INT, and TERM signals: do not re-enter `onExit`.
     trap "" HUP INT TERM
+
+    if [ -n "$SLEEP_PID" ]; then
+        kill $SLEEP_PID
+    fi
 
     log "* Logout in progress..."
     if ! pid=$(pgrep "$PROGRAM_NAME"); then
@@ -58,4 +63,5 @@ log "  - Waiting for logout..."
 # Sleep for approx. a year. Every user should shutdown their computer at
 # least once a year.
 sleep 31536000 &
-wait
+SLEEP_PID=$!
+wait $SLEEP_PID

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -1,19 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 PROGRAM_NAME="gpg-agent"
 LOGFILE="$HOME/Library/Logs/shutdown-gpg-agent.log"
 AGENT_SOCKET_DEFAULT="$HOME/.gnupg/S.gpg-agent"
 AGENT_SOCKET_ALT="/tmp/gpg-agent/$USER/S.gpg-agent"
 
-function log {
+log() {
     current_date=$(date "+%Y-%m-%d %H:%M:%S")
     echo "$current_date: $1"
-    if [[ "$2" != "" ]]; then
+    if [ "$2" != "" ]; then
         echo ""
     fi
 }
 
-function onExit {
+onExit() {
+    # Ignore future HUP, INT, and TERM signals: do not re-enter `onExit`.
+    trap "" HUP INT TERM
+
     log "* Logout in progress..."
     if ! pid=$(pgrep "$PROGRAM_NAME"); then
         log "* $PROGRAM_NAME not running, no reason to kill it." 1
@@ -38,7 +41,7 @@ function onExit {
         rm -f "${AGENT_SOCKET_ALT}.ssh"
     fi
 
-    if [[ "$RET" != "0" ]]; then
+    if [ "$RET" != "0" ]; then
         log "* Failed to kill $PROGRAM_NAME. Sorry..." 1
     else
         log "* Successfully killed $PROGRAM_NAME. job well done" 1
@@ -53,7 +56,7 @@ exec >> $LOGFILE 2>&1
 log "* Setting up kill event listeners"
 
 # Setup the signals to trap which will invoke the onExit handler.
-trap onExit SIGHUP SIGINT SIGTERM
+trap onExit HUP INT TERM
 
 log "  - successfully setup kill event listeners"
 log "  - waiting for logout..."

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -19,11 +19,11 @@ onExit() {
 
     log "* Logout in progress..."
     if ! pid=$(pgrep "$PROGRAM_NAME"); then
-        log "* $PROGRAM_NAME not running, no reason to kill it." 1
+        log "* $PROGRAM_NAME not running. Exiting." 1
         return
     fi
 
-    log "  - killing gpg-agent..."
+    log "  - Killing gpg-agent..."
     kill -9 $pid
 
     RET=$?
@@ -37,9 +37,9 @@ onExit() {
     done
 
     if [ "$RET" != "0" ]; then
-        log "* Failed to kill $PROGRAM_NAME. Sorry..." 1
+        log "* Failed to kill $PROGRAM_NAME." 1
     else
-        log "* Successfully killed $PROGRAM_NAME. job well done" 1
+        log "* Successfully killed $PROGRAM_NAME." 1
     fi
 
     exit 0
@@ -53,8 +53,8 @@ log "* Setting up kill event listeners"
 # Setup the signals to trap which will invoke the onExit handler.
 trap onExit HUP INT TERM
 
-log "  - successfully setup kill event listeners"
-log "  - waiting for logout..."
+log "  - Successfully setup kill event listeners"
+log "  - Waiting for logout..."
 # Sleep for approx. a year. Every user should shutdown their computer at
 # least once a year.
 sleep 31536000 &

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -19,39 +19,38 @@ function agentPID {
 
 function onExit {
     log "* Logout in progress..."
-	pid="$(agentPID)"
-	
-	if [[ "$pid" == "" ]]; then
-	    log "* gpg-agent not running, no reason to kill it." 1
-	    return
-	fi
-	
-	log "  - killing gpg-agent..."
-	kill -9 $pid
-	
-	RET=$?
-	
-	# Now remove the S.gpg-agent file
-	if [ -S "$AGENT_SOCKET_DEFAULT" ]; then
-	    log "Removing S.gpg-agent sockets at $AGENT_SOCKET_DEFAULT" 1
-	    rm -f "$AGENT_SOCKET_DEFAULT"
-	    rm -f "${AGENT_SOCKET_DEFAULT}.ssh"
-	fi
-	
-	if [ -S "$AGENT_SOCKET_ALT" ]; then
-	    log "Removing S.gpg-agent sockets at $AGENT_SOCKET_ALT" 1
-	    rm -f "$AGENT_SOCKET_ALT"
-	    rm -f "${AGENT_SOCKET_ALT}.ssh"
-	fi
-	
-	if [[ "$RET" != "0" ]]; then
-	    log "* Failed to kill gpg-agent. Sorry..." 1
-	else
-	    log "* Successfully killed gpg-agent. job well done" 1
-	fi
-	
-	
-	exit 0
+    pid="$(agentPID)"
+
+    if [[ "$pid" == "" ]]; then
+        log "* gpg-agent not running, no reason to kill it." 1
+        return
+    fi
+
+    log "  - killing gpg-agent..."
+    kill -9 $pid
+
+    RET=$?
+
+    # Now remove the S.gpg-agent file
+    if [ -S "$AGENT_SOCKET_DEFAULT" ]; then
+        log "Removing S.gpg-agent sockets at $AGENT_SOCKET_DEFAULT" 1
+        rm -f "$AGENT_SOCKET_DEFAULT"
+        rm -f "${AGENT_SOCKET_DEFAULT}.ssh"
+    fi
+
+    if [ -S "$AGENT_SOCKET_ALT" ]; then
+        log "Removing S.gpg-agent sockets at $AGENT_SOCKET_ALT" 1
+        rm -f "$AGENT_SOCKET_ALT"
+        rm -f "${AGENT_SOCKET_ALT}.ssh"
+    fi
+
+    if [[ "$RET" != "0" ]]; then
+        log "* Failed to kill gpg-agent. Sorry..." 1
+    else
+        log "* Successfully killed gpg-agent. job well done" 1
+    fi
+
+    exit 0
 }
 
 # Setting up the logfile.
@@ -59,13 +58,12 @@ exec >> $LOGFILE 2>&1
 
 log "* Setting up kill event listeners"
 
-# Setup the signals to trap which will invoke
-# the onExit handler.
+# Setup the signals to trap which will invoke the onExit handler.
 trap onExit SIGHUP SIGINT SIGTERM
 
 log "  - successfully setup kill event listeners"
 log "  - waiting for logout..."
-# Sleep for approx. a year. Every user should shutdown there computer at
+# Sleep for approx. a year. Every user should shutdown their computer at
 # least once a year.
 sleep 31536000 &
 wait $!

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -16,7 +16,7 @@ function log {
 function onExit {
     log "* Logout in progress..."
     if ! pid=$(pgrep "$PROGRAM_NAME"); then
-        log "* gpg-agent not running, no reason to kill it." 1
+        log "* $PROGRAM_NAME not running, no reason to kill it." 1
         return
     fi
 
@@ -39,9 +39,9 @@ function onExit {
     fi
 
     if [[ "$RET" != "0" ]]; then
-        log "* Failed to kill gpg-agent. Sorry..." 1
+        log "* Failed to kill $PROGRAM_NAME. Sorry..." 1
     else
-        log "* Successfully killed gpg-agent. job well done" 1
+        log "* Successfully killed $PROGRAM_NAME. job well done" 1
     fi
 
     exit 0

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -28,18 +28,13 @@ onExit() {
 
     RET=$?
 
-    # Now remove the S.gpg-agent file
-    if [ -S "$AGENT_SOCKET_DEFAULT" ]; then
-        log "Removing S.gpg-agent sockets at $AGENT_SOCKET_DEFAULT" 1
-        rm -f "$AGENT_SOCKET_DEFAULT"
-        rm -f "${AGENT_SOCKET_DEFAULT}.ssh"
-    fi
-
-    if [ -S "$AGENT_SOCKET_ALT" ]; then
-        log "Removing S.gpg-agent sockets at $AGENT_SOCKET_ALT" 1
-        rm -f "$AGENT_SOCKET_ALT"
-        rm -f "${AGENT_SOCKET_ALT}.ssh"
-    fi
+    # Remove the S.gpg-agent sockets, if present.
+    for socket_path in "$AGENT_SOCKET_DEFAULT" "$AGENT_SOCKET_ALT"; do
+        if [ -S "$socket_path" ]; then
+            log "Removing S.gpg-agent sockets at $socket_path" 1
+            rm -f "$socket_path" "$socket_path.ssh"
+        fi
+    done
 
     if [ "$RET" != "0" ]; then
         log "* Failed to kill $PROGRAM_NAME. Sorry..." 1

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -58,4 +58,4 @@ log "  - waiting for logout..."
 # Sleep for approx. a year. Every user should shutdown their computer at
 # least once a year.
 sleep 31536000 &
-wait $!
+wait

--- a/payload/libexec/shutdown-gpg-agent
+++ b/payload/libexec/shutdown-gpg-agent
@@ -13,15 +13,9 @@ function log {
     fi
 }
 
-function agentPID {
-    echo $(ps axc | awk "{if (\$5==\"$PROGRAM_NAME\") print \$1}");
-}
-
 function onExit {
     log "* Logout in progress..."
-    pid="$(agentPID)"
-
-    if [[ "$pid" == "" ]]; then
+    if ! pid=$(pgrep "$PROGRAM_NAME"); then
         log "* gpg-agent not running, no reason to kill it." 1
         return
     fi


### PR DESCRIPTION
This change is being done to help clean up/improve idioms in shutdown-gpg-agent, and to make the script more portable on other systems (assuming of course, a similar filesystem layout to OS X).

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>