### PR TITLE
libs: libksba 1.6.3

### DIFF
--- a/libs.json
+++ b/libs.json
@@ -62,8 +62,8 @@
 	{
 		"name": "libksba",
 		"url": "https://gnupg.org/ftp/gcrypt/libksba/libksba-${VERSION}.tar.bz2",
-		"version": "1.6.2",
-		"sha256": "fce01ccac59812bddadffacff017dac2e4762bdb6ebc6ffe06f6ed4f6192c971",
+		"version": "1.6.3",
+		"sha256": "3f72c68db30971ebbf14367527719423f0a4d5f8103fc9f4a1c01a9fa440de5c",
 		"installed_file": "lib/libksba.dylib"
 	},
 	{


### PR DESCRIPTION
This is a follow up to b0931f81ec5473f77904c44383b1ddc7b1ce3a47. An newer version of libksba, with an additional interger overflow fix, has been released.

>  * Fix another integer overflow in the CRL parser.  [T6284]
>  Release-info: https://dev.gnupg.org/T6304